### PR TITLE
Fix issue building on latest MacOS 12.1 with Apple Silicon.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (BUILD_STATICLIB)
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation -framework IOKit")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation -framework IOKit -framework Security")
 endif()
 
 


### PR DESCRIPTION
Security framework added to linker flags due to build error:

```
Undefined symbols for architecture arm64:
  "_SecTaskCopyValueForEntitlement", referenced from:
      _darwin_detach_kernel_driver in libusb-1.0.a(darwin_usb.o)
  "_SecTaskCreateFromSelf", referenced from:
      _darwin_detach_kernel_driver in libusb-1.0.a(darwin_usb.o)
ld: symbol(s) not found for architecture arm64
```